### PR TITLE
Wiki 489/rails 4 support

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,6 @@
+Encoding:
+  Enabled: false
+Documentation:
+  Enabled: false
+LineLength:
+  Max: 120

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # rack-attack-rate-limit changelog
 
+
 ## 0.1.0
 
 * Initial release.

--- a/lib/rack/attack/rate-limit.rb
+++ b/lib/rack/attack/rate-limit.rb
@@ -1,11 +1,17 @@
+unless defined?(Rack::Attack)
+  module Rack
+    class Attack
+    end
+  end
+end
+
 module Rack
-  module Attack
+  class Attack
     class RateLimit
-      
       RACK_ATTACK_KEY = 'rack.attack.throttle_data'
 
       attr_reader :app, :options
-  
+
       def initialize(app, options = {})
         @app = app
         @options = default_options.merge(options)
@@ -13,31 +19,31 @@ module Rack
 
       def call(env)
         # If env does not have necessary data to extract rate limit data for the provider, then app.call
-        return app.call(env) unless rate_limit_available?(env)     
+        return app.call(env) unless rate_limit_available?(env)
         # Otherwise, add rate limit headers
         status, headers, body = app.call(env)
         add_rate_limit_headers!(headers, env)
-        [status, headers, body]  
+        [status, headers, body]
       end
-    
+
       # Returns env key used by Rack::Attack to namespace data
       #
       # Returns string
       def rack_attack_key
         RACK_ATTACK_KEY
       end
-  
+
       # Default options to configure Rack::RateLimit
       #
       # Returns hash
       def default_options
         { throttle: 'throttle' }
       end
-      
+
       def throttle
         options[:throttle] || ''
       end
-    
+
       # Return hash of headers with Rate Limiting data
       #
       # headers - Hash of headers
@@ -48,9 +54,9 @@ module Rack
         headers['X-RateLimit-Remaining']  = rate_limit_remaining(env).to_s
         headers
       end
-  
+
       protected
-  
+
       # RateLimit upper limit from Rack::Attack
       #
       # env - Hash
@@ -59,7 +65,7 @@ module Rack
       def rate_limit_limit(env)
         env[rack_attack_key][throttle][:limit]
       end
-  
+
       # RateLimit remaining request from Rack::Attack
       #
       # env - Hash
@@ -68,17 +74,16 @@ module Rack
       def rate_limit_remaining(env)
         rate_limit_limit(env) - env[rack_attack_key][throttle][:count]
       end
-      
+
       # Rate Limit available method for Rack::Attack provider
       # Checks the key identifed by options[:namespace] under the rack.attak.throttle_data env hash key
       #
       # env - Hash
       #
-      # Returns boolean 
+      # Returns boolean
       def rate_limit_available?(env)
-        env.key?(rack_attack_key) and env[rack_attack_key].key?(throttle)
+        env.key?(rack_attack_key) && env[rack_attack_key].key?(throttle)
       end
-  
     end
   end
 end

--- a/lib/rack/attack/rate-limit/version.rb
+++ b/lib/rack/attack/rate-limit/version.rb
@@ -1,7 +1,7 @@
 module Rack
-  module Attack
+  class Attack
     class RateLimit
-      VERSION = "0.1.0"
+      VERSION = '0.1.0'
     end
   end
 end

--- a/rack-attack-rate-limit.gemspec
+++ b/rack-attack-rate-limit.gemspec
@@ -18,12 +18,13 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
-  
+
   spec.add_dependency 'rack'
 
   spec.add_development_dependency "bundler", "~> 1.3"
-  spec.add_development_dependency "rake"
-  spec.add_development_dependency "rspec"
-  spec.add_development_dependency "rack-test"
-  
+  spec.add_development_dependency 'rake'
+  spec.add_development_dependency 'rspec'
+  spec.add_development_dependency 'rack-test'
+  spec.add_development_dependency 'rubocop'
+
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,10 +5,8 @@ require 'rack/test'
 require 'rack/attack/rate-limit'
 
 RSpec::configure do |config|
-  
+
   config.treat_symbols_as_metadata_keys_with_true_values = true
-  config.formatter = :documentation  
+  config.formatter = :documentation
   config.tty = true
-  config.color_enabled = true
-  
 end


### PR DESCRIPTION
Rack::Attack should be a class, not a module.  Define Rack::Attack if not already defined. Minor style changes.
