### PR TITLE
Set the 'X-RateLimit-Reset' header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # rack-attack-rate-limit changelog
 
+## master
+
+* Set the 'X-RateLimit-Reset' header to the number of seconds until the current throttle period expires.
+
 ## 1.1.0
 
 * Add support for multiple throttles.

--- a/lib/rack/attack/rate-limit.rb
+++ b/lib/rack/attack/rate-limit.rb
@@ -53,6 +53,7 @@ module Rack
         throttle_data = throttle_data_closest_to_limit(env)
         headers['X-RateLimit-Limit']      = rate_limit_limit(throttle_data).to_s
         headers['X-RateLimit-Remaining']  = rate_limit_remaining(throttle_data).to_s
+        headers['X-RateLimit-Reset']      = rate_limit_reset(throttle_data).to_s
         headers
       end
 
@@ -74,6 +75,16 @@ module Rack
       # Returns Fixnum
       def rate_limit_remaining(throttle_data)
         rate_limit_limit(throttle_data) - throttle_data[:count]
+      end
+
+      # RateLimit seconds until the current period expires from Rack::Attack
+      #
+      # env - Hash
+      #
+      # Returns Fixnum
+      def rate_limit_reset(throttle_data)
+        throttle_period = throttle_data[:period]
+        throttle_period - (Time.now.to_i % throttle_period)
       end
 
       # Rate Limit available method for Rack::Attack provider

--- a/spec/rack/attack/rate-limit_spec.rb
+++ b/spec/rack/attack/rate-limit_spec.rb
@@ -25,6 +25,7 @@ describe Rack::Attack::RateLimit do
     it 'should not create RateLimit headers' do
       last_response.header.key?('X-RateLimit-Limit').should be false
       last_response.header.key?('X-RateLimit-Remaining').should be false
+      last_response.header.key?('X-RateLimit-Reset').should be false
     end
 
   end
@@ -36,16 +37,18 @@ describe Rack::Attack::RateLimit do
 
     let(:request_limit) { (1..10_000).to_a.sample }
     let(:request_count) { (1..(request_limit - 10)).to_a.sample }
+    let(:request_period) { rand(60..3600) }
 
     context 'one throttle only' do
 
       let(:rack_attack_throttle_data) do
-        { "#{throttle_one}" => { count: request_count, limit: request_limit } }
+        { "#{throttle_one}" => { count: request_count, limit: request_limit, period: request_period} }
       end
 
       it 'should include RateLimit headers' do
         last_response.header.key?('X-RateLimit-Limit').should be true
         last_response.header.key?('X-RateLimit-Remaining').should be true
+        last_response.header.key?('X-RateLimit-Reset').should be true
       end
 
       it 'should return correct rate limit in header' do
@@ -54,6 +57,12 @@ describe Rack::Attack::RateLimit do
 
       it 'should return correct remaining calls in header' do
         last_response.header['X-RateLimit-Remaining'].to_i.should eq(request_limit - request_count)
+      end
+
+      it 'should returns the number of seconds remaining in the current throttle period' do
+        current_epoch_time = Time.now.to_i
+        seconds_until_next_period = request_period - (current_epoch_time % request_period)
+        last_response.header['X-RateLimit-Reset'].to_i.should eq(seconds_until_next_period)
       end
     end
 
@@ -69,17 +78,20 @@ describe Rack::Attack::RateLimit do
 
       let(:request_limits) { 3.times.map { (1..10_000).to_a.sample } }
       let(:request_counts) { 3.times.map { |index| (1..(request_limits[index] - 10)).to_a.sample } }
+      let(:request_periods) { 3.times.map { rand(60..3600) } }
 
       let(:rack_attack_throttle_data) do
         data = {}
         [throttle_one, throttle_two, throttle_three].each_with_index do |thr, thr_index|
-          data["#{thr}"] = { count: request_counts[thr_index], limit: request_limits[thr_index] }
+          data["#{thr}"] = { count: request_counts[thr_index], limit: request_limits[thr_index], period: request_periods[thr_index] }
         end
         data
       end
+
       it 'should include RateLimit headers' do
         last_response.header.key?('X-RateLimit-Limit').should be true
         last_response.header.key?('X-RateLimit-Remaining').should be true
+        last_response.header.key?('X-RateLimit-Reset').should be true
       end
 
       describe 'header values' do
@@ -94,6 +106,12 @@ describe Rack::Attack::RateLimit do
 
         it 'should return correct remaining calls' do
           last_response.header['X-RateLimit-Remaining'].to_i.should eq(request_differences[min_index])
+        end
+
+        it 'should return the correct number of seconds until the current throttled period expires' do
+          current_epoch_time = Time.now.to_i
+          seconds_until_next_period = request_periods[min_index] - (current_epoch_time % request_periods[min_index])
+          last_response.header['X-RateLimit-Reset'].to_i.should eq(seconds_until_next_period)
         end
       end
     end


### PR DESCRIPTION
Set the 'X-RateLimit-Reset' header to the number of seconds until the current throttle expires. 

This implements what was proposed here: https://github.com/jbyck/rack-attack-rate-limit/issues/2. 
